### PR TITLE
正規表現で任意の文字を抜き出す機能を実装

### DIFF
--- a/src/main/java/org/example/Main.java
+++ b/src/main/java/org/example/Main.java
@@ -1,8 +1,94 @@
 package org.example;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.MatchResult;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
+
 public class Main {
 
   public static void main(String[] args) {
-    System.out.println("Hello world!");
+
+//    チャットGPTでランダムな8文字の文字列を30個生成
+    List<String> randomStrings = Arrays.asList(
+        "漢2㍍Qw8掘り",
+        "狂k1ōタゴV3eú4",
+        "M0ヤdàā3モのg",
+        "的G5mュザしæKぬ",
+        "ご1行ŝñō1YÅ7",
+        "ヨ6ヮD漢9Vォ3",
+        "À行7の工ジ達",
+        "チャZōア9仏き",
+        "8ヤ1ū2ヤャýi",
+        "3にア6yォɾō",
+        "2㍍Qw8掘りe矛",
+        "1ōタゴV3eú4毎",
+        "0ヤdàā3モのg",
+        "G5mュザしæKぬゾ",
+        "1行ŝñō1YÅ7毎",
+        "6ヮD漢9Vォ3甘",
+        "行7の工ジ達サ",
+        "Zōア9仏き漢演",
+        "ヤ1ū2ヤャýiē",
+        "にア6yォɾō行",
+        "1Qw8掘りe矛7",
+        "ōタゴV3eú4毎ビ",
+        "ヤdàā3モのg阿",
+        "mュザしæKぬゾ0",
+        "行ŝñō1YÅ7毎的",
+        "ヮD漢9Vォ3甘y",
+        "7の工ジ達サ8",
+        "A9仏き漢演習b",
+        "ヤ1ū2ヤャýiēで"
+    );
+
+    Pattern numberPattern = Pattern.compile("\\d+");
+    Pattern englishPattern = Pattern.compile("[a-zA-Z]+");
+    Pattern uppercasePattern = Pattern.compile("[A-Z]+");
+    Pattern japanesePattern = Pattern.compile("[\\p{IsHiragana}\\p{IsKatakana}\\p{IsHan}]+");
+    Pattern otherEnglishPattern = Pattern.compile("[^\\p{Alnum}]+");
+
+//    数字だけを抜き出す正規表現
+    List<List<String>> numberList = randomStrings.stream()
+        .map(v -> numberPattern.matcher(v).results()
+            .map(MatchResult::group)
+            .collect(Collectors.toList()))
+        .toList();
+    System.out.println("数字だけ抜き出し\n" + numberList);
+
+//    英字だけを抜き出す正規表現
+    List<List<String>> stringList = randomStrings.stream()
+        .map(v -> englishPattern.matcher(v).results()
+            .map(MatchResult::group)
+            .collect(Collectors.toList()))
+        .toList();
+    System.out.println("英字だけ抜き出し\n" + stringList);
+
+    //    英数字の大文字だけを抜き出す正規表現
+    List<List<String>> uppercaseList = randomStrings.stream()
+        .map(v -> uppercasePattern.matcher(v).results()
+            .map(MatchResult::group)
+            .collect(Collectors.toList()))
+        .toList();
+    System.out.println("英数字の大文字だけ抜き出し\n" + uppercaseList);
+
+    //    日本語だけを抜き出す正規表現
+    List<List<String>> japaneseList = randomStrings.stream()
+        .map(v -> japanesePattern.matcher(v).results()
+            .map(MatchResult::group)
+            .collect(Collectors.toList()))
+        .toList();
+    System.out.println("日本語だけ抜き出し\n" + japaneseList);
+
+    //    英数字以外を抜き出す正規表現
+    List<List<String>> otherEngilishList = randomStrings.stream()
+        .map(v -> otherEnglishPattern.matcher(v).results()
+            .map(MatchResult::group)
+            .collect(Collectors.toList()))
+        .toList();
+    System.out.println("英数字以外を抜き出し\n" + otherEngilishList);
   }
 }

--- a/src/main/java/org/example/Main.java
+++ b/src/main/java/org/example/Main.java
@@ -3,9 +3,7 @@ package org.example;
 import java.util.Arrays;
 import java.util.List;
 import java.util.regex.MatchResult;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collector;
 import java.util.stream.Collectors;
 
 public class Main {
@@ -14,35 +12,11 @@ public class Main {
 
 //    チャットGPTでランダムな8文字の文字列を30個生成
     List<String> randomStrings = Arrays.asList(
-        "漢2㍍Qw8掘り",
-        "狂k1ōタゴV3eú4",
-        "M0ヤdàā3モのg",
-        "的G5mュザしæKぬ",
-        "ご1行ŝñō1YÅ7",
-        "ヨ6ヮD漢9Vォ3",
-        "À行7の工ジ達",
-        "チャZōア9仏き",
-        "8ヤ1ū2ヤャýi",
-        "3にア6yォɾō",
-        "2㍍Qw8掘りe矛",
-        "1ōタゴV3eú4毎",
-        "0ヤdàā3モのg",
-        "G5mュザしæKぬゾ",
-        "1行ŝñō1YÅ7毎",
-        "6ヮD漢9Vォ3甘",
-        "行7の工ジ達サ",
-        "Zōア9仏き漢演",
-        "ヤ1ū2ヤャýiē",
-        "にア6yォɾō行",
-        "1Qw8掘りe矛7",
-        "ōタゴV3eú4毎ビ",
-        "ヤdàā3モのg阿",
-        "mュザしæKぬゾ0",
-        "行ŝñō1YÅ7毎的",
-        "ヮD漢9Vォ3甘y",
-        "7の工ジ達サ8",
-        "A9仏き漢演習b",
-        "ヤ1ū2ヤャýiēで"
+        "漢2㍍Qw8掘り", "狂k1ōタゴV3eú4", "M0ヤdàā3モのg", "的G5mュザしæKぬ", "ご1行ŝñō1YÅ7",
+        "ヨ6ヮD漢9Vォ3", "À行7の工ジ達", "チャZōア9仏き", "8ヤ1ū2ヤャýi", "3にア6yォɾō", "2㍍Qw8掘りe矛",
+        "1ōタゴV3eú4毎", "0ヤdàā3モのg", "G5mュザしæKぬゾ", "1行ŝñō1YÅ7毎", "6ヮD漢9Vォ3甘", "行7の工ジ達サ",
+        "Zōア9仏き漢演", "ヤ1ū2ヤャýiē", "にア6yォɾō行", "1Qw8掘りe矛7", "ōタゴV3eú4毎ビ", "ヤdàā3モのg阿",
+        "mュザしæKぬゾ0", "行ŝñō1YÅ7毎的", "ヮD漢9Vォ3甘y", "7の工ジ達サ8", "A9仏き漢演習b", "ヤ1ū2ヤャýiēで"
     );
 
     Pattern numberPattern = Pattern.compile("\\d+");


### PR DESCRIPTION
## 機能概要
・ChatGPTでランダムな文字列を8文字で30個もつリストを生成。
・以下の条件で文字列の中から抜き出すよう正規表現を設定し、文字列リストを一つ一つチェックしそれぞれ条件に合う文字を抽出。
①数字　②英字　③大文字英数字　④日本語　⑤英数字以外

## 詳細
・Pattern.compileで正規表現パターンをコンパイル
・ストリーム処理でListの各要素（v）からPattern.matcher(v)で文字を抽出→.results()で結果を取得→.mapで取得した連続文字はそれぞれグループ化→複数連続文字をListとしてコレクション→List（全体）の中にList（各要素の複数連続文字列）を格納

## 動作確認
・生成した文字列
<img width="815" alt="image" src="https://github.com/masehideki/New-Java-10/assets/135149708/9950a42e-235d-4b65-8bb9-98fc7962aa4c">
・実行結果（スクリーンショットが見切れたため、最初の要素だけ確認）
<img width="1314" alt="image" src="https://github.com/masehideki/New-Java-10/assets/135149708/08fbee83-7dbe-42d3-8150-fb9e94659c5a">
